### PR TITLE
modif requete au backend

### DIFF
--- a/src/main/java/com/pharmacie/App.java
+++ b/src/main/java/com/pharmacie/App.java
@@ -88,6 +88,7 @@ public class App extends Application {
                     HttpRequest request = HttpRequest.newBuilder()
                             .uri(URI.create(API_URL))
                             .header("Content-Type", "application/json")
+                            .header("Authorization", "Bearer " + Global.getToken())
                             .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
                             .build();
 
@@ -111,6 +112,8 @@ public class App extends Application {
                 // Dans setupLoginTaskHandlers (App.java)
 if (response != null && response.isSuccess()) {
     String role = response.getRole();
+
+    Global.setToken(response.getToken()); //ajout du token
     
     if ("PHARMACIEN_ADJOINT".equalsIgnoreCase(role) 
         || "APPRENTI".equalsIgnoreCase(role) 
@@ -119,7 +122,8 @@ if (response != null && response.isSuccess()) {
         LoggedSeller.getInstance().setUser(
             response.getId(),
             response.getNom(),
-            response.getPrenom(), 
+            response.getPrenom(),
+            response.getToken(),
             role
         );
         

--- a/src/main/java/com/pharmacie/controller/GestionCommandeController.java
+++ b/src/main/java/com/pharmacie/controller/GestionCommandeController.java
@@ -244,6 +244,7 @@ public class GestionCommandeController {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(FOURNISSEURS_URL+"/"+ id.toString()))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
     
@@ -281,6 +282,7 @@ public class GestionCommandeController {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(EMPLOYES_URL+"/"+employeId.toString()))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
     
@@ -404,6 +406,7 @@ public class GestionCommandeController {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(fullUrl))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .PUT(HttpRequest.BodyPublishers.ofString(jsonQuantites.toString()))
                     .build();
             

--- a/src/main/java/com/pharmacie/controller/PasserCommandeController.java
+++ b/src/main/java/com/pharmacie/controller/PasserCommandeController.java
@@ -184,6 +184,7 @@ public class PasserCommandeController {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(FOURNISSEURS_URL))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
     

--- a/src/main/java/com/pharmacie/model/dto/LoginResponse.java
+++ b/src/main/java/com/pharmacie/model/dto/LoginResponse.java
@@ -8,6 +8,7 @@ public class LoginResponse {
     private String prenom;
     private String role;
     private UUID id;
+    private String token;
 
     // Setters nécessaires pour Gson
     public void setSuccess(boolean success) { this.success = success; }
@@ -15,6 +16,7 @@ public class LoginResponse {
     public void setPrenom(String prenom) { this.prenom = prenom; }
     public void setRole(String role) { this.role = role; }
     public void setId(UUID id) { this.id = id; }
+    public void setToken(String token) { this.token = token; }
 
     // Getters
     public boolean isSuccess() { return success; }
@@ -22,4 +24,5 @@ public class LoginResponse {
     public String getPrenom() { return prenom; }
     public String getRole() { return role; }
     public UUID getId() { return id; }
+    public String getToken() { return token; }
 }

--- a/src/main/java/com/pharmacie/service/AdminApi.java
+++ b/src/main/java/com/pharmacie/service/AdminApi.java
@@ -40,6 +40,7 @@ public class AdminApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(ADMIN_URL))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -63,6 +64,7 @@ public class AdminApi {
             String encodedQuery = java.net.URLEncoder.encode(query, "UTF-8");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(ADMIN_URL + "/search?query=" + encodedQuery))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -85,6 +87,7 @@ public class AdminApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(ADMIN_URL + "/" + idPersonne))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .DELETE()
                     .build();
 
@@ -108,6 +111,7 @@ public class AdminApi {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(ADMIN_URL + "/" + idPersonne))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .PUT(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 
@@ -179,6 +183,7 @@ public class AdminApi {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(ADMIN_URL))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 

--- a/src/main/java/com/pharmacie/service/AnalyseVenteApi.java
+++ b/src/main/java/com/pharmacie/service/AnalyseVenteApi.java
@@ -31,6 +31,7 @@ public class AnalyseVenteApi {
     private static Map<LocalDate, AnalyseVenteData> fetchData(String endpoint) throws Exception {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(API_BASE_URL + endpoint))
+                .header("Authorization", "Bearer " + Global.getToken())
                 .GET()
                 .build();
     

--- a/src/main/java/com/pharmacie/service/ApiRest.java
+++ b/src/main/java/com/pharmacie/service/ApiRest.java
@@ -66,6 +66,7 @@ public class ApiRest {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .timeout(Duration.ofSeconds(15))
                 .GET()
                 .build();
@@ -99,6 +100,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(15))
                     .GET()
                     .build();
@@ -157,6 +159,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(800))
                     .GET()
                     .build();
@@ -204,6 +207,7 @@ public class ApiRest {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(finalUrl))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .timeout(Duration.ofSeconds(15))
                 .GET()
                 .build();
@@ -246,6 +250,7 @@ public class ApiRest {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(finalUrl))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .timeout(Duration.ofSeconds(15))
                 .GET()
                 .build();
@@ -283,6 +288,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(15))
                     .GET()
                     .build();
@@ -320,6 +326,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(15))
                     .GET()
                     .build();
@@ -350,6 +357,7 @@ public class ApiRest {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .timeout(Duration.ofSeconds(15))
                 .GET()
                 .build();
@@ -399,6 +407,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(15))
                     .GET()
                     .build();
@@ -503,6 +512,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(15))
                     .DELETE()
                     .build();
@@ -575,6 +585,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(80))
                     .GET()
                     .build();
@@ -834,6 +845,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(15))
                     .GET()
                     .build();
@@ -869,6 +881,7 @@ public class ApiRest {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(url))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .timeout(Duration.ofSeconds(15))
                     .GET()
                     .build();
@@ -894,6 +907,7 @@ public class ApiRest {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .timeout(Duration.ofSeconds(15))
                 .GET()
                 .build();
@@ -1025,6 +1039,7 @@ public class ApiRest {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .GET()
                 .build();
 
@@ -1047,8 +1062,10 @@ public class ApiRest {
      */
     public static Dashboard getDashboardRequest() throws Exception {
         HttpRequest request = HttpRequest.newBuilder()
-                .uri(URI.create(API_BASE_URL + "/dashboard"))
+                .uri(URI.create(API_BASE_URL + "/" +
+                        "dashboard"))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .GET()
                 .build();
 

--- a/src/main/java/com/pharmacie/service/ApprentiApi.java
+++ b/src/main/java/com/pharmacie/service/ApprentiApi.java
@@ -40,6 +40,7 @@ public class ApprentiApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(APPRENTI_URL))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -63,6 +64,7 @@ public class ApprentiApi {
             String encodedQuery = java.net.URLEncoder.encode(query, "UTF-8");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(APPRENTI_URL + "/search?term=" + encodedQuery))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -85,6 +87,7 @@ public class ApprentiApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(APPRENTI_URL + "/" + idPersonne))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .DELETE()
                     .build();
 
@@ -105,6 +108,7 @@ public class ApprentiApi {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(APPRENTI_URL + "/" + idPersonne))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .PUT(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 
@@ -160,6 +164,7 @@ public class ApprentiApi {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(APPRENTI_URL))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 

--- a/src/main/java/com/pharmacie/service/CommandeService.java
+++ b/src/main/java/com/pharmacie/service/CommandeService.java
@@ -36,6 +36,7 @@ public class CommandeService {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(COMMANDES_URL))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .GET()
                 .build();
         
@@ -210,6 +211,7 @@ public class CommandeService {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(url))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .PUT(HttpRequest.BodyPublishers.noBody())
                 .build();
         

--- a/src/main/java/com/pharmacie/service/FournisseurApi.java
+++ b/src/main/java/com/pharmacie/service/FournisseurApi.java
@@ -37,6 +37,7 @@ public class FournisseurApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(FOURNISSEUR_URL))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -58,6 +59,7 @@ public class FournisseurApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(FOURNISSEUR_URL + "/" + id))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -78,6 +80,7 @@ public class FournisseurApi {
             String encodedEmail = java.net.URLEncoder.encode(email, "UTF-8");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(FOURNISSEUR_URL + "/email/" + encodedEmail))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -98,6 +101,7 @@ public class FournisseurApi {
             String encodedTel = java.net.URLEncoder.encode(telephone, "UTF-8");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(FOURNISSEUR_URL + "/telephone/" + encodedTel))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -153,6 +157,7 @@ public class FournisseurApi {
             String encodedQuery = java.net.URLEncoder.encode(query, "UTF-8");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(FOURNISSEUR_URL + "/search?q=" + encodedQuery))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
     
@@ -173,6 +178,7 @@ public class FournisseurApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(FOURNISSEUR_URL + "/" + id))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .DELETE()
                     .build();
 

--- a/src/main/java/com/pharmacie/service/PharmacienAdjointApi.java
+++ b/src/main/java/com/pharmacie/service/PharmacienAdjointApi.java
@@ -40,6 +40,7 @@ public class PharmacienAdjointApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PHARMACIEN_ADJOINT_URL))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -63,6 +64,7 @@ public class PharmacienAdjointApi {
             String encodedQuery = java.net.URLEncoder.encode(query, "UTF-8");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PHARMACIEN_ADJOINT_URL + "/search?term=" + encodedQuery))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -85,6 +87,7 @@ public class PharmacienAdjointApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PHARMACIEN_ADJOINT_URL + "/" + idPersonne))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .DELETE()
                     .build();
 
@@ -105,6 +108,7 @@ public class PharmacienAdjointApi {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PHARMACIEN_ADJOINT_URL + "/" + idPersonne))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .PUT(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 
@@ -159,6 +163,7 @@ public class PharmacienAdjointApi {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PHARMACIEN_ADJOINT_URL))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 

--- a/src/main/java/com/pharmacie/service/PreparateurApi.java
+++ b/src/main/java/com/pharmacie/service/PreparateurApi.java
@@ -40,6 +40,7 @@ public class PreparateurApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PREPARATEUR_URL))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -63,6 +64,7 @@ public class PreparateurApi {
             String encodedQuery = java.net.URLEncoder.encode(query, "UTF-8");
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PREPARATEUR_URL + "/search?term=" + encodedQuery))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .GET()
                     .build();
 
@@ -85,6 +87,7 @@ public class PreparateurApi {
         try {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PREPARATEUR_URL + "/" + idPersonne))
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .DELETE()
                     .build();
 
@@ -105,6 +108,7 @@ public class PreparateurApi {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PREPARATEUR_URL + "/" + idPersonne))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .PUT(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 
@@ -159,6 +163,7 @@ public class PreparateurApi {
             HttpRequest request = HttpRequest.newBuilder()
                     .uri(URI.create(PREPARATEUR_URL))
                     .header("Content-Type", "application/json")
+                    .header("Authorization", "Bearer " + Global.getToken())
                     .POST(HttpRequest.BodyPublishers.ofString(requestBody))
                     .build();
 

--- a/src/main/java/com/pharmacie/util/Global.java
+++ b/src/main/java/com/pharmacie/util/Global.java
@@ -12,6 +12,14 @@ public class Global {
     public static String getBaseUrl() {
         return BASE_URL;
     }
+    private static String token = "";
+    public static String getToken() {
+        return token;
+    }
+    public static void setToken(String token) {
+        Global.token = token;
+    }
+
     public static UUID getClientId() {
         return GlobalClient.getIdPersonne();
     }

--- a/src/main/java/com/pharmacie/util/HttpClientUtil.java
+++ b/src/main/java/com/pharmacie/util/HttpClientUtil.java
@@ -35,6 +35,7 @@ public class HttpClientUtil {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(BASE_URL + "/client/telephone/" + telephone))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .GET()
                 .build();
         HttpResponse<String> response = HttpClient.newHttpClient()
@@ -58,6 +59,7 @@ public class HttpClientUtil {
         HttpRequest request = HttpRequest.newBuilder()
                 .uri(URI.create(BASE_URL + "/client"))
                 .header("Content-Type", "application/json")
+                .header("Authorization", "Bearer " + Global.getToken())
                 .POST(HttpRequest.BodyPublishers.ofString(jsonBody))
                 .build();
         HttpResponse<String> response = HttpClient.newHttpClient()

--- a/src/main/java/com/pharmacie/util/LoggedSeller.java
+++ b/src/main/java/com/pharmacie/util/LoggedSeller.java
@@ -8,6 +8,7 @@ public class LoggedSeller {
     private String nom;
     private String prenom;
     private String role;
+    private String token;
 
     public static LoggedSeller getInstance() {
         if (instance == null) {
@@ -16,11 +17,12 @@ public class LoggedSeller {
         return instance;
     }
 
-    public void setUser(UUID id, String nom, String prenom, String role) {
+    public void setUser(UUID id, String nom, String prenom, String role, String token) {
         this.id = id;
         this.nom = nom;
         this.prenom = prenom;
         this.role = role;
+        this.token = token;
     }
     public String getRole() {
         return this.role;
@@ -36,5 +38,6 @@ public class LoggedSeller {
         this.nom = null;
         this.prenom = null;
         this.role = null;
+        this.token = null;
     }
 }


### PR DESCRIPTION
## Summary by Sourcery

Add bearer token authentication to backend API requests by managing the token in Global and attaching it to all HTTP calls.

Enhancements:
- Introduce a global token store in Global with getters/setters and extend LoginResponse to capture the token
- Update login flow to save the token post-authentication and propagate it to LoggedSeller
- Attach "Authorization: Bearer <token>" header to all HttpRequest builders across service and controller classes